### PR TITLE
Update getHashidConnection to use getTable

### DIFF
--- a/src/EloquentHashids.php
+++ b/src/EloquentHashids.php
@@ -31,7 +31,7 @@ trait EloquentHashids
    */
   public static function getHashidConnection(Model $model)
   {
-    return 'table.' . $model->table;
+    return 'table.' . $model->getTable();
   }
 
   /**


### PR DESCRIPTION
If $table is not set on the model then we get the error

`InvalidArgumentException with message 'Connection [table.] not configured.'`

by using `$model->getTable()` will get a default from the model rather than just having a blank value.
